### PR TITLE
some refactorings and code organizing

### DIFF
--- a/extension/haptics/Haptic.hx
+++ b/extension/haptics/Haptic.hx
@@ -1,9 +1,10 @@
 package extension.haptics;
 
+import extension.haptics.backends.IHapticBackend;
 #if android
-import extension.haptics.android.HapticAndroid;
+import extension.haptics.backends.AndroidHapticBackend;
 #elseif ios
-import extension.haptics.ios.HapticIOS;
+import extension.haptics.backends.IOSHapticBackend;
 #end
 
 /**
@@ -11,36 +12,41 @@ import extension.haptics.ios.HapticIOS;
  */
 class Haptic
 {
+
+	private static var _backend:Null<IHapticBackend>;
+	public static var backend(get, never):IHapticBackend;
+
+	static function get_backend():IHapticBackend
+	{
+		if (_backend == null) _backend = createBackend();
+		return _backend;
+	}
+
+	static function createBackend():IHapticBackend
+	{
+		#if android
+        return new AndroidHapticBackend();
+        #elseif ios
+        return new IOSHapticBackend();
+        #else
+        return new EmptyHapticBackend();
+        #end
+	}
+
 	/**
 	 * Initializes the haptic system for the current platform.
-	 * 
-	 * This method delegates to the platform-specific implementation:
-	 * - Android: Calls `HapticAndroid.initialize()`.
-	 * - iOS: Calls `HapticIOS.initialize()`.
 	 */
 	public static function initialize():Void
 	{
-		#if android
-		HapticAndroid.initialize();
-		#elseif ios
-		HapticIOS.initialize();
-		#end
+		backend.initialize();
 	}
 
 	/**
 	 * Disposes of the haptic system for the current platform.
-	 * 
-	 * This method delegates to the platform-specific implementation:
-	 * - Android: Calls `HapticAndroid.dispose()`.
-	 * - iOS: Calls `HapticIOS.dispose()`.
 	 */
 	public static function dispose():Void
 	{
-		#if android
-		HapticAndroid.dispose();
-		#elseif ios
-		HapticIOS.dispose();
-		#end
+		backend.dispose();
 	}
 
 	/**
@@ -56,11 +62,7 @@ class Haptic
 	 */
 	public static function vibrateOneShot(duration:Float, amplitude:Float, sharpness:Float):Void
 	{
-		#if android
-		HapticAndroid.vibrateOneShot(Math.floor(duration * 1000), Math.floor(Math.max(1, Math.min(255, amplitude * 255))));
-		#elseif ios
-		HapticIOS.vibrateOneShot(duration, Math.max(0, Math.min(1, amplitude)), Math.max(0, Math.min(1, sharpness)));
-		#end
+		backend.vibrateOneShot(duration, amplitude, sharpness);
 	}
 
 	/**
@@ -76,30 +78,6 @@ class Haptic
 	 */
 	public static function vibratePattern(durations:Array<Float>, amplitudes:Array<Float>, sharpnesses:Array<Float>):Void
 	{
-		#if android
-		final intTimings:Array<Int> = [0]; // The first element is the delay.
-
-		for (i in 0...durations.length)
-			intTimings.push(Math.floor(durations[i] * 1000));
-
-		final intAmplitudes:Array<Int> = [0]; // Since the first element is the delay, it won't have an amplitude.
-
-		for (i in 0...amplitudes.length)
-			intAmplitudes.push(Math.floor(Math.max(1, Math.min(255, amplitudes[i] * 255))));
-
-		HapticAndroid.vibratePattern(intTimings, intAmplitudes);
-		#elseif ios
-		final singleAmplitudes:Array<Single> = [];
-
-		for (i in 0...amplitudes.length)
-			singleAmplitudes[i] = (amplitudes[i] : Single);
-
-		final singleSharpnesses:Array<Single> = [];
-
-		for (i in 0...sharpnesses.length)
-			singleSharpnesses[i] = (sharpnesses[i] : Single);
-
-		HapticIOS.vibratePattern(durations, singleAmplitudes, singleSharpnesses);
-		#end
+		backend.vibratePattern(durations, amplitudes, sharpnesses);
 	}
 }

--- a/extension/haptics/Haptic.hx
+++ b/extension/haptics/Haptic.hx
@@ -9,6 +9,21 @@ import extension.haptics.backends.IOSHapticBackend;
 
 /**
  * This class provides a cross-platform interface for haptic feedback functionality.
+ * Can be safely accessed cross platform, as any unsupported platforms (desktop/html5) simply just call empty backend functions
+ * So usage is generally
+ * Haptic.initialize(); 
+ * Haptic.vibrateOneShot(0.5, 0.2, 0.8); // Calls a one-shot vibration that lasts 0.5 seconds, at 0.2 intensity, and at 0.8 sharpness
+ * 
+ * #if ios
+ * // iOS specific functions are in HapticIOS.hx 
+ * HapticIOS.vibratePatternFromData(Assets.getBytes("data/heartbeats.ahap")); 
+ * #end
+ * 
+ * #if android
+ * // Android specific functions are in HapticAndroid.hx
+ * if(HapticAndroid.isPrimitiveSupported(HapticAndroid.PRIMITIVE_CLICK))
+ * 		trace("Has Android Click Primitive!");
+ * #end
  */
 class Haptic
 {

--- a/extension/haptics/HapticAndroid.hx
+++ b/extension/haptics/HapticAndroid.hx
@@ -1,0 +1,85 @@
+package extension.haptics;
+
+#if android
+import extension.haptics.backends.AndroidHapticBackend;
+
+/**
+ * Android specific haptics functions
+ * Note: Make sure `Haptic.initialize()` gets called before you attempt using these!
+ */
+class HapticAndroid
+{
+    /**
+	 * Represents a short, sharp click vibration.
+	 */
+	public static final PRIMITIVE_CLICK:Int = 1;
+
+	/**
+	 * Represents a low-intensity tick vibration.
+	 */
+	public static final PRIMITIVE_LOW_TICK:Int = 8;
+
+	/**
+	 * Represents a quick, falling vibration pattern.
+	 */
+	public static final PRIMITIVE_QUICK_FALL:Int = 6;
+
+	/**
+	 * Represents a quick, rising vibration pattern.
+	 */
+	public static final PRIMITIVE_QUICK_RISE:Int = 4;
+
+	/**
+	 * Represents a slow, rising vibration pattern.
+	 */
+	public static final PRIMITIVE_SLOW_RISE:Int = 5;
+
+	/**
+	 * Represents a spinning vibration pattern.
+	 */
+	public static final PRIMITIVE_SPIN:Int = 3;
+
+	/**
+	 * Represents a heavy, thud-like vibration.
+	 */
+	public static final PRIMITIVE_THUD:Int = 2;
+
+	/**
+	 * Represents a standard tick vibration.
+	 */
+	public static final PRIMITIVE_TICK:Int = 7;
+
+    /**
+	 * Checks if a specific vibration primitive is supported.
+	 * 
+	 * @param primitiveId The ID of the vibration primitive.
+	 * 
+	 * @return `true` if the primitive is supported, false otherwise.
+	 */
+	public static function isPrimitiveSupported(primitiveId:Int):Bool
+	{
+        @:privateAccess
+		final isPrimitiveSupportedJNI:Null<Dynamic> = AndroidHapticBackend.createJNIStaticMethod('org/haxe/extension/Haptic', 'isPrimitiveSupported', '(I)Z');
+
+		if (isPrimitiveSupportedJNI != null)
+			return isPrimitiveSupportedJNI(primitiveId);
+
+		return false;
+	}
+
+    /**
+	 * Triggers a predefined vibration pattern using primitive IDs, scales, and delays.
+	 * 
+	 * @param primitiveIds An array of integers representing predefined vibration primitive IDs.
+	 * @param scales An array of scaling factors (0.0 to 1.0) for the intensity of each primitive.
+	 * @param delays An array of delays in milliseconds before each primitive is triggered.
+	 */
+    public static function vibratePredefined(primitiveIds:Array<Int>, scales:Array<Float>, delays:Array<Int>):Void
+	{
+        @:privateAccess
+		final vibratePredefinedJNI:Null<Dynamic> = AndroidHapticBackend.createJNIStaticMethod('org/haxe/extension/Haptic', 'vibratePredefined', '([I[D[I)V');
+
+		if (vibratePredefinedJNI != null)
+			vibratePredefinedJNI(primitiveIds, scales, delays);
+	}
+}

--- a/extension/haptics/HapticIOS.hx
+++ b/extension/haptics/HapticIOS.hx
@@ -1,0 +1,33 @@
+package extension.haptics;
+
+import extension.haptics.backends.IOSHapticBackend;
+#if ios
+/**
+ * IOS specific haptics functions and features
+ * Note: Make sure `Haptic.initialize()` gets called before you attempt using these!
+ */
+@:buildXml('<include name="${haxelib:extension-haptics}/project/haptic-ios/Build.xml" />')
+@:headerInclude('haptic.hpp')
+class HapticIOS
+{
+    /**
+	 * Triggers a haptic vibration pattern using the provided pattern data.
+	 * 
+	 * @param data The AHAP pattern data as a `Bytes` object.
+	 */
+	public static function vibratePatternFromData(data:Bytes):Void
+	{
+		if (data != null)
+			hapticVibratePatternFromData(cast cpp.Pointer.arrayElem(data.getData(), 0).constRaw, data.length);
+	}
+
+    /**
+	 * Native function to triggers a pattern vibration using a pattern file (.ahap).
+	 *
+	 * @param bytes The buffer containing data for the new object.
+	 * @param length The number of bytes to copy from bytes.
+	 */
+	@:native('hapticVibratePatternFromData')
+	extern public static function hapticVibratePatternFromData(bytes:cpp.RawConstPointer<cpp.Void>, len:cpp.SizeT):Void;
+}
+#end

--- a/extension/haptics/backends/AndroidHapticBackend.hx
+++ b/extension/haptics/backends/AndroidHapticBackend.hx
@@ -12,46 +12,7 @@ using Lambda;
  */
 class AndroidHapticBackend implements IHapticBackend
 {
-	/**
-	 * Represents a short, sharp click vibration.
-	 */
-	public static final PRIMITIVE_CLICK:Int = 1;
-
-	/**
-	 * Represents a low-intensity tick vibration.
-	 */
-	public static final PRIMITIVE_LOW_TICK:Int = 8;
-
-	/**
-	 * Represents a quick, falling vibration pattern.
-	 */
-	public static final PRIMITIVE_QUICK_FALL:Int = 6;
-
-	/**
-	 * Represents a quick, rising vibration pattern.
-	 */
-	public static final PRIMITIVE_QUICK_RISE:Int = 4;
-
-	/**
-	 * Represents a slow, rising vibration pattern.
-	 */
-	public static final PRIMITIVE_SLOW_RISE:Int = 5;
-
-	/**
-	 * Represents a spinning vibration pattern.
-	 */
-	public static final PRIMITIVE_SPIN:Int = 3;
-
-	/**
-	 * Represents a heavy, thud-like vibration.
-	 */
-	public static final PRIMITIVE_THUD:Int = 2;
-
-	/**
-	 * Represents a standard tick vibration.
-	 */
-	public static final PRIMITIVE_TICK:Int = 7;
-
+	
 	/**
 	 * Cache for storing created static JNI method references.
 	 */
@@ -122,37 +83,6 @@ class AndroidHapticBackend implements IHapticBackend
 			vibratePatternJNI(durations, amplitudes);
 	}
 
-	/**
-	 * Checks if a specific vibration primitive is supported.
-	 * 
-	 * @param primitiveId The ID of the vibration primitive.
-	 * 
-	 * @return `true` if the primitive is supported, false otherwise.
-	 */
-	public static function isPrimitiveSupported(primitiveId:Int):Bool
-	{
-		final isPrimitiveSupportedJNI:Null<Dynamic> = createJNIStaticMethod('org/haxe/extension/Haptic', 'isPrimitiveSupported', '(I)Z');
-
-		if (isPrimitiveSupportedJNI != null)
-			return isPrimitiveSupportedJNI(primitiveId);
-
-		return false;
-	}
-
-	/**
-	 * Triggers a predefined vibration pattern using primitive IDs, scales, and delays.
-	 * 
-	 * @param primitiveIds An array of integers representing predefined vibration primitive IDs.
-	 * @param scales An array of scaling factors (0.0 to 1.0) for the intensity of each primitive.
-	 * @param delays An array of delays in milliseconds before each primitive is triggered.
-	 */
-	public static function vibratePredefined(primitiveIds:Array<Int>, scales:Array<Float>, delays:Array<Int>):Void
-	{
-		final vibratePredefinedJNI:Null<Dynamic> = createJNIStaticMethod('org/haxe/extension/Haptic', 'vibratePredefined', '([I[D[I)V');
-
-		if (vibratePredefinedJNI != null)
-			vibratePredefinedJNI(primitiveIds, scales, delays);
-	}
 
 	/**
 	 * Retrieves or creates a cached static method reference.

--- a/extension/haptics/backends/EmptyHapticBackend.hx
+++ b/extension/haptics/backends/EmptyHapticBackend.hx
@@ -1,0 +1,11 @@
+package extension.haptics.backends;
+
+class EmptyHapticBackend implements IHapticBackend
+{
+    public function new():Void {}
+    public function initialize():Void {}
+    public function dispose():Void {}
+    public function isSupported():Bool return false;
+    public function vibrateOneShot(duration:Float,amplitude:Float, sharpness:Float):Void {}
+    public function vibratePattern(durations:Array<Float>, amplitudes:Array<Float>, sharpnesses:Array<Float>):Void {}
+}

--- a/extension/haptics/backends/IHapticBackend.hx
+++ b/extension/haptics/backends/IHapticBackend.hx
@@ -1,0 +1,9 @@
+package extension.haptics.backends;
+
+interface IHapticBackend
+{
+    function initialize():Void;
+    function dispose():Void;
+    function vibrateOneShot(duration:Float, amplitude:Float, sharpness:Float):Void;
+    function vibratePattern(durations:Array<Float>, amplitudes:Array<Float>, sharpnesses:Array<Float>):Void;
+}

--- a/extension/haptics/backends/IOSHapticBackend.hx
+++ b/extension/haptics/backends/IOSHapticBackend.hx
@@ -65,16 +65,6 @@ class IOSHapticBackend implements IHapticBackend
 			timings.length);
 	}
 
-	/**
-	 * Triggers a haptic vibration pattern using the provided pattern data.
-	 * 
-	 * @param data The AHAP pattern data as a `Bytes` object.
-	 */
-	public function vibratePatternFromData(data:Bytes):Void
-	{
-		if (data != null)
-			hapticVibratePatternFromData(cast cpp.Pointer.arrayElem(data.getData(), 0).constRaw, data.length);
-	}
 
 	/**
 	 * Native function to initialize the haptic engine.
@@ -110,13 +100,5 @@ class IOSHapticBackend implements IHapticBackend
 	extern public static function hapticVibratePattern(durations:cpp.RawConstPointer<Float>, intensities:cpp.RawConstPointer<Single>,
 		sharpnesses:cpp.RawConstPointer<Single>, count:Int):Void;
 
-	/**
-	 * Native function to triggers a pattern vibration using a pattern file (.ahap).
-	 *
-	 * @param bytes The buffer containing data for the new object.
-	 * @param length The number of bytes to copy from bytes.
-	 */
-	@:native('hapticVibratePatternFromData')
-	extern public static function hapticVibratePatternFromData(bytes:cpp.RawConstPointer<cpp.Void>, len:cpp.SizeT):Void;
 }
 #end

--- a/project/haptic-ios/src/haptic.mm
+++ b/project/haptic-ios/src/haptic.mm
@@ -196,7 +196,7 @@
 			return;
 		}
 
-		[player startAtTime:0 error:&error];
+		[player startAtTime:CHHapticTimeImmediate error:&error];
 
 		if (error)
 			NSLog(@"Failed to start haptic player: %@", error.localizedDescription);
@@ -258,7 +258,7 @@
 			return;
 		}
 
-		[player startAtTime:0 error:&error];
+		[player startAtTime:CHHapticTimeImmediate error:&error];
 
 		if (error)
 			NSLog(@"Failed to start haptic player: %@", error.localizedDescription);

--- a/test/source/Main.hx
+++ b/test/source/Main.hx
@@ -34,7 +34,7 @@ class Main extends Sprite
 		#if android
 		extension.haptics.Haptic.vibratePattern([0.5, 0.1, 0.8, 0.2, 1.0], [1.0, 0.5, 1.0, 0.3, 0.8], [0.5, 0.5, 1.0, 0.3, 0.8]);
 		#elseif ios
-		extension.haptics.ios.HapticIOS.vibratePatternFromData(Assets.getBytes('assets/Heartbeats.ahap'));
+		extension.haptics.HapticIOS.vibratePatternFromData(Assets.getBytes('assets/Heartbeats.ahap'));
 		#end
 	}
 }


### PR DESCRIPTION
- split the code into backends. These are the files that connect with our native java/obj-c code, and are meant to be our "cross-platform" functionality that we call from `Haptic.hx`
    - HapticIOS.hx -> IOSHapticBackend.hx
    - HapticAndroid.hx -> AndroidHapticBackend.hx
    - EmptyBackend.hx for use when on desktop/html5, so we don't need to wrap every `Haptic.vibrate()` call in a `#if mobile` conditional. In there are just empty functions so it does nothing.
- `HapticIOS.hx` and `HapticAndroid.hx` have now become our "platform specific" functions. Things like `vibratePatternFromData()` to load (currently) apple specific .ahap files, are in `HapticIOS.hx` and `isPrimitiveSupported()` is now in `HapticAndroid.hx` as it's Android specific functionality. 
- `Haptic.hx` now has no platform specific code inside of it, it's merely a facade which calls our backends.

These changes should allow easier organization

Lil other misc changes
- Changed from 0 to `CHHapticTimeImmediate` which could have no effect at all and just be value 0. But I saw it in some of the Apple sample code so I figured we can use it as our constant here.

I have only tested on iOS, but *core functionality* should generally be the same. All the previous developer facing function calls should work the exact same way (`Haptic.vibrateOneshot()` should vibrate the same way as previous). 
I have android phone on me for further testing of this, but if u have notes lemme know @MAJigsaw77 